### PR TITLE
Add SECURITY.md (security contact / reporting guidance)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,25 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security support is defined by the maintainers of this repository.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+In general:
+- Current stable/release branches: supported
+- End-of-life (EOL) releases: unsupported
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please do not open public issues or pull requests for security vulnerabilities.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Preferred channel:
+- Use GitHub “Report a vulnerability” (Security Advisories / Private Vulnerability Reporting), if enabled on this repository.
+
+If GitHub reporting is not available:
+- Contact the vendor’s official security/PSIRT channel (maintainers define).
+
+Please include:
+- Affected component(s) and version(s)
+- Impact description + CVSS v3.1 vector (if possible)
+- Reproduction steps (HTTP request / curl / minimal script)
+- Configuration/network assumptions
+- Evidence (logs/screenshots), without real secrets


### PR DESCRIPTION
Adds a SECURITY.md to document preferred private reporting channel (GitHub Advisories if enabled) and discourage public disclosure.